### PR TITLE
Also expose dBm values for RX/TX laser power & thresholds

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 func printVersion() {
 	fmt.Println("transceiver-exporter")
 	fmt.Printf("Version: %s\n", version)
-	fmt.Println("Author(s): @fluepke")
+	fmt.Println("Author(s): @fluepke, @BarbarossaTM")
 	fmt.Println("Metrics Exporter for pluggable transceivers on Linux based hosts / switches")
 }
 

--- a/main.go
+++ b/main.go
@@ -3,13 +3,14 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/prometheus/common/log"
-	"gitlab.com/wobcom/transceiver-exporter/transceiver-collector"
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/log"
+	transceivercollector "gitlab.com/wobcom/transceiver-exporter/transceiver-collector"
 )
 
 const version string = "1.0"
@@ -20,6 +21,7 @@ var (
 	metricsPath              = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics")
 	collectInterfaceFeatures = flag.Bool("collector.interface-features.enable", true, "Collect interface features")
 	excludeInterfaces        = flag.String("exclude.interfaces", "", "Comma seperated list of interfaces to exclude")
+	powerUnitdBm             = flag.Bool("collector.optical-power-in-dbm", false, "Report optical powers in dBm instead of mW (default false -> mW)")
 )
 
 func main() {
@@ -57,25 +59,25 @@ func startServer() {
 }
 
 type transceiverCollectorWrapper struct {
-    collector *transceivercollector.TransceiverCollector
+	collector *transceivercollector.TransceiverCollector
 }
 
-func (t transceiverCollectorWrapper) Collect (ch chan<- prometheus.Metric) {
-    errs := make(chan error)
-    done := make(chan struct{})
-    go t.collector.Collect(ch, errs, done)
-    for {
-        select {
-        case err := <-errs:
-            log.Errorf("Error while collecting metrics: %v", err)
-        case <- done:
-            return
-        }
-    }
+func (t transceiverCollectorWrapper) Collect(ch chan<- prometheus.Metric) {
+	errs := make(chan error)
+	done := make(chan struct{})
+	go t.collector.Collect(ch, errs, done)
+	for {
+		select {
+		case err := <-errs:
+			log.Errorf("Error while collecting metrics: %v", err)
+		case <-done:
+			return
+		}
+	}
 }
 
 func (t transceiverCollectorWrapper) Describe(ch chan<- *prometheus.Desc) {
-    t.collector.Describe(ch)
+	t.collector.Describe(ch)
 }
 
 func handleMetricsRequest(w http.ResponseWriter, request *http.Request) {
@@ -85,10 +87,10 @@ func handleMetricsRequest(w http.ResponseWriter, request *http.Request) {
 	for index, excludedIfaceName := range excludedIfaceNames {
 		excludedIfaceNames[index] = strings.Trim(excludedIfaceName, " ")
 	}
-	transceiverCollector := transceivercollector.NewCollector(excludedIfaceNames, *collectInterfaceFeatures)
-    wrapper := &transceiverCollectorWrapper{
-        collector: transceiverCollector,
-    }
+	transceiverCollector := transceivercollector.NewCollector(excludedIfaceNames, *collectInterfaceFeatures, *powerUnitdBm)
+	wrapper := &transceiverCollectorWrapper{
+		collector: transceiverCollector,
+	}
 
 	registry.MustRegister(wrapper)
 	promhttp.HandlerFor(registry, promhttp.HandlerOpts{

--- a/transceiver-collector/util.go
+++ b/transceiver-collector/util.go
@@ -1,5 +1,7 @@
 package transceivercollector
 
+import "math"
+
 func contains(l []string, test string) bool {
 	for _, item := range l {
 		if item == test {
@@ -14,4 +16,8 @@ func boolToFloat64(b bool) float64 {
 		return 1
 	}
 	return 0
+}
+
+func milliwattsToDbm(mw float64) float64 {
+	return 10 * math.Log10(mw)
 }


### PR DESCRIPTION
As discussed at RIPE, here's the PR to expose dBm metrics for RX/TX laser power and thresholds with a boolean command line switch to switch between mW and dBm to reduce redundant metrics. The default stays with mW of course.

```
# ethtool -m swp1 | grep dBm
	Laser output power                        : 0.6770 mW / -1.69 dBm
	Receiver signal average optical power     : 0.5806 mW / -2.36 dBm
	Laser output power high alarm threshold   : 1.7783 mW / 2.50 dBm
	Laser output power low alarm threshold    : 0.0955 mW / -10.20 dBm
	Laser output power high warning threshold : 1.1220 mW / 0.50 dBm
	Laser output power low warning threshold  : 0.1514 mW / -8.20 dBm
	Laser rx power high alarm threshold       : 1.7783 mW / 2.50 dBm
	Laser rx power low alarm threshold        : 0.0229 mW / -16.40 dBm
	Laser rx power high warning threshold     : 1.1220 mW / 0.50 dBm
	Laser rx power low warning threshold      : 0.0363 mW / -14.40 dBm
```

```
$ wget -O- -q http://localhost:9458/metrics | grep dbm | grep swp1
transceiver_laser_rx_power_dbm{interface="swp1",laser_index="0"} -2.3612296850434507
transceiver_laser_rx_power_high_alarm_threshold_dbm{interface="swp1",laser_index="0"} 2.500050284868957
transceiver_laser_rx_power_high_warning_threshold_dbm{interface="swp1",laser_index="0"} 0.4999285692014265
transceiver_laser_rx_power_low_alarm_threshold_dbm{interface="swp1",laser_index="0"} -16.40164517660112
transceiver_laser_rx_power_low_warning_threshold_dbm{interface="swp1",laser_index="0"} -14.400933749638874
transceiver_laser_tx_power_dbm{interface="swp1",laser_index="0"} -1.6941133131485564
transceiver_laser_tx_power_high_alarm_threshold_dbm{interface="swp1",laser_index="0"} 2.500050284868957
transceiver_laser_tx_power_high_warning_threshold_dbm{interface="swp1",laser_index="0"} 0.4999285692014265
transceiver_laser_tx_power_low_alarm_threshold_dbm{interface="swp1",laser_index="0"} -10.199966284162535
transceiver_laser_tx_power_low_warning_threshold_dbm{interface="swp1",laser_index="0"} -8.198741248359461
```

This also works for multi lane/channel transceiver, paste skipped for brevity.