### PR TITLE
Support regx exclude interface list

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ var (
 	listenAddress            = flag.String("web.listen-address", "[::]:9458", "Address to listen on")
 	metricsPath              = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics")
 	collectInterfaceFeatures = flag.Bool("collector.interface-features.enable", true, "Collect interface features")
-	excludeInterfaces        = flag.String("exclude.interfaces", "", "Comma seperated list of interfaces to exclude")
+	excludeInterfaces        = flag.String("exclude.interfaces", "", "Comma seperated list of interfaces regular to exclude")
 	powerUnitdBm             = flag.Bool("collector.optical-power-in-dbm", false, "Report optical powers in dBm instead of mW (default false -> mW)")
 )
 
@@ -83,9 +83,12 @@ func (t transceiverCollectorWrapper) Describe(ch chan<- *prometheus.Desc) {
 func handleMetricsRequest(w http.ResponseWriter, request *http.Request) {
 	registry := prometheus.NewRegistry()
 
-	excludedIfaceNames := strings.Split(*excludeInterfaces, ",")
-	for index, excludedIfaceName := range excludedIfaceNames {
-		excludedIfaceNames[index] = strings.Trim(excludedIfaceName, " ")
+	var excludedIfaceNames []string
+	if len(*excludeInterfaces) != 0 {
+		excludedIfaceNames = strings.Split(*excludeInterfaces, ",")
+		for index, excludedIfaceName := range excludedIfaceNames {
+			excludedIfaceNames[index] = strings.Trim(excludedIfaceName, " ")
+		}
 	}
 	transceiverCollector := transceivercollector.NewCollector(excludedIfaceNames, *collectInterfaceFeatures, *powerUnitdBm)
 	wrapper := &transceiverCollectorWrapper{

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ func startServer() {
             <head><title>transceiver-exporter (Version ` + version + `)</title></head>
             <body>
             <h1>transceiver-exporter</h1>
+			<p><a href="/metrics">Metrics</a></p>
             </body>
             </html>`))
 	})

--- a/transceiver-collector/collector.go
+++ b/transceiver-collector/collector.go
@@ -356,7 +356,7 @@ func (t *TransceiverCollector) exportMetricsForInterface(iface *ethtool.Interfac
 
 func exportDriverInfoMetricsForInterface(ifaceName string, driverInfo *ethtool.DriverInfo, ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(driverDesc, prometheus.GaugeValue, 1, ifaceName, driverInfo.DriverName)
-	ch <- prometheus.MustNewConstMetric(driverVersionDesc, prometheus.GaugeValue, 1, ifaceName, driverInfo.DriverVersion)
+	ch <- prometheus.MustNewConstMetric(driverVersionDesc, prometheus.GaugeValue, 1, ifaceName, quoteToascii(driverInfo.DriverVersion))
 	ch <- prometheus.MustNewConstMetric(firmwareVersionDesc, prometheus.GaugeValue, 1, ifaceName, driverInfo.FirmwareVersion)
 	ch <- prometheus.MustNewConstMetric(busInfoDesc, prometheus.GaugeValue, 1, ifaceName, driverInfo.BusInfo)
 	ch <- prometheus.MustNewConstMetric(expansionRomVersionDesc, prometheus.GaugeValue, 1, ifaceName, driverInfo.ExpansionRomVersion)

--- a/transceiver-collector/util.go
+++ b/transceiver-collector/util.go
@@ -3,6 +3,7 @@ package transceivercollector
 import (
 	"math"
 	"regexp"
+	"strconv"
 )
 
 func contains(l []string, test string) bool {
@@ -24,4 +25,10 @@ func boolToFloat64(b bool) float64 {
 
 func milliwattsToDbm(mw float64) float64 {
 	return 10 * math.Log10(mw)
+}
+
+func quoteToascii(str string) string {
+	textQuoted := strconv.QuoteToASCII(str)
+	textUnquoted := textQuoted[1 : len(textQuoted)-1]
+	return textUnquoted
 }

--- a/transceiver-collector/util.go
+++ b/transceiver-collector/util.go
@@ -1,10 +1,14 @@
 package transceivercollector
 
-import "math"
+import (
+	"math"
+	"regexp"
+)
 
 func contains(l []string, test string) bool {
 	for _, item := range l {
-		if item == test {
+		match, _ := regexp.MatchString(item, test)
+		if match {
 			return true
 		}
 	}


### PR DESCRIPTION
### fix: To solve character encoding error in driver version return
some network interface return driver version
Maybe the country of manufacturer, the character "\x00" in driver version response, it leads the metrics pages context-Type change to "binary", like this:
```bash
transceiver_driver_version_info{driver_version="1.0.0\\x00-50-generic",interface="enp0s5"} 1
transceiver_driver_version_info{driver_version="1.0\\x00.0-50-generic",interface="cali2d8e0dfad7a"} 1
transceiver_driver_version_info{driver_version="1.0\\x00.0-50-generic",interface="calib073cd807d5"} 1
transceiver_driver_version_info{driver_version="1.0\\x00.0-50-generic",interface="calidf4d15675a8"} 1
transceiver_driver_version_info{driver_version="1.0\\x00.0-50-generic",interface="calif0538e521e7"} 1
transceiver_driver_version_info{driver_version="2.3\\x00.0-50-generic",interface="docker0"} 1
transceiver_driver_version_info{driver_version="5.15.0-50-generic",interface="kube-ipvs0"} 1
```

### feat: support regx exclude interface list
In virtualized operating system, like installed docker proxmox and other, so much virtual bridge device, like `docker0` `docker1` `bond0` `bond1` `vmbr0v5050` `vmbr1v3000` and other, so i added the regx support, just with the `-exclude.interfaces` parameter, same as before.
```bash
./transceiver-exporter -exclude.interfaces bond*,vmbr*,tap*,docker*,eth0
```