### PR TITLE
add flag to disable reporting on admin down interfaces

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var (
 	collectInterfaceFeatures = flag.Bool("collector.interface-features.enable", true, "Collect interface features")
 	excludeInterfaces        = flag.String("exclude.interfaces", "", "Comma seperated list of interfaces to exclude")
 	includeInterfaces        = flag.String("include.interfaces", "", "Comma seperated list of interfaces to include")
+	excludeInterfacesDown    = flag.Bool("exclude.interfaces-down", false, "Don't report on interfaces being management DOWN")
 	powerUnitdBm             = flag.Bool("collector.optical-power-in-dbm", false, "Report optical powers in dBm instead of mW (default false -> mW)")
 )
 
@@ -98,7 +99,7 @@ func handleMetricsRequest(w http.ResponseWriter, request *http.Request) {
 			includedIfaceNames[index] = strings.Trim(includedIfaceName, " ")
 		}
 	}
-	transceiverCollector := transceivercollector.NewCollector(excludedIfaceNames, includedIfaceNames, *collectInterfaceFeatures, *powerUnitdBm)
+	transceiverCollector := transceivercollector.NewCollector(excludedIfaceNames, includedIfaceNames, *excludeInterfacesDown, *collectInterfaceFeatures, *powerUnitdBm)
 	wrapper := &transceiverCollectorWrapper{
 		collector: transceiverCollector,
 	}


### PR DESCRIPTION
This PR adds an optional flag to disable reporting of transceiver details when an interface is administratively down. By default this feature is turned off, keeping the current behavior as is. At the moment, even on disabled interfaces, the transceiver data is reported and may alert for incomplete fiber connection. Using this flag those false positive alerts are removed.