### PR TITLE
use regex to include/exclude interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,14 @@ Usage of ./transceiver-exporter:
         Report optical powers in dBm instead of mW (default false -> mW)
   -exclude.interfaces string
         Comma seperated list of interfaces to exclude
+  -exclude.interfaces-regex string
+        Regexp of interfaces to exclude
   -exclude.interfaces-down
         Don't report on interfaces being management DOWN
   -include.interfaces string
         Comma seperated list of interfaces to include
+  -include.interfaces-regex string
+        Regexp of interfaces to include
   -version
         Print version and exit
   -web.listen-address string

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	transceivercollector "github.com/wobcom/transceiver-exporter/transceiver-collector"
 )
 
-const version string = "1.4.1"
+const version string = "1.5.0"
 
 var (
 	showVersion              = flag.Bool("version", false, "Print version and exit")
@@ -22,6 +22,8 @@ var (
 	collectInterfaceFeatures = flag.Bool("collector.interface-features.enable", true, "Collect interface features")
 	excludeInterfaces        = flag.String("exclude.interfaces", "", "Comma seperated list of interfaces to exclude")
 	includeInterfaces        = flag.String("include.interfaces", "", "Comma seperated list of interfaces to include")
+	excludeInterfacesRegex   = flag.String("exclude.interfaces-regex", "", "Regex of interfaces to exclude")
+	includeInterfaceRegex    = flag.String("include.interfaces-regex", "", "Regex of interfaces to include")
 	excludeInterfacesDown    = flag.Bool("exclude.interfaces-down", false, "Don't report on interfaces being management DOWN")
 	powerUnitdBm             = flag.Bool("collector.optical-power-in-dbm", false, "Report optical powers in dBm instead of mW (default false -> mW)")
 )
@@ -99,7 +101,7 @@ func handleMetricsRequest(w http.ResponseWriter, request *http.Request) {
 			includedIfaceNames[index] = strings.Trim(includedIfaceName, " ")
 		}
 	}
-	transceiverCollector := transceivercollector.NewCollector(excludedIfaceNames, includedIfaceNames, *excludeInterfacesDown, *collectInterfaceFeatures, *powerUnitdBm)
+	transceiverCollector := transceivercollector.NewCollector(excludedIfaceNames, includedIfaceNames, *excludeInterfacesRegex, *includeInterfaceRegex, *excludeInterfacesDown, *collectInterfaceFeatures, *powerUnitdBm)
 	wrapper := &transceiverCollectorWrapper{
 		collector: transceiverCollector,
 	}

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	transceivercollector "github.com/wobcom/transceiver-exporter/transceiver-collector"
 )
 
-const version string = "1.5.0"
+const version string = "1.4.1"
 
 var (
 	showVersion              = flag.Bool("version", false, "Print version and exit")

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -23,9 +24,12 @@ var (
 	excludeInterfaces        = flag.String("exclude.interfaces", "", "Comma seperated list of interfaces to exclude")
 	includeInterfaces        = flag.String("include.interfaces", "", "Comma seperated list of interfaces to include")
 	excludeInterfacesRegex   = flag.String("exclude.interfaces-regex", "", "Regex of interfaces to exclude")
-	includeInterfaceRegex    = flag.String("include.interfaces-regex", "", "Regex of interfaces to include")
+	includeInterfacesRegex   = flag.String("include.interfaces-regex", "", "Regex of interfaces to include")
 	excludeInterfacesDown    = flag.Bool("exclude.interfaces-down", false, "Don't report on interfaces being management DOWN")
 	powerUnitdBm             = flag.Bool("collector.optical-power-in-dbm", false, "Report optical powers in dBm instead of mW (default false -> mW)")
+
+	excludeInterfacesRegexCompiled = &regexp.Regexp{}
+	includeInterfacesRegexCompiled = &regexp.Regexp{}
 )
 
 func main() {
@@ -36,6 +40,10 @@ func main() {
 		os.Exit(0)
 	}
 
+	if err := compileRegexFlags(); err != nil {
+		log.Fatalf(err.Error())
+	}
+
 	startServer()
 }
 
@@ -44,6 +52,21 @@ func printVersion() {
 	fmt.Printf("Version: %s\n", version)
 	fmt.Println("Author(s): @fluepke, @BarbarossaTM, @vidister")
 	fmt.Println("Metrics Exporter for pluggable transceivers on Linux based hosts / switches")
+}
+
+// compileRegexFlags compiles the cli regex flags into the global variables
+// and returns an error if the regex is invalid
+func compileRegexFlags() error {
+	var err error
+	excludeInterfacesRegexCompiled, err = regexp.Compile(*excludeInterfacesRegex)
+	if err != nil {
+		return fmt.Errorf("error compiling exclude.interfaces-regex: %v", err)
+	}
+	includeInterfacesRegexCompiled, err = regexp.Compile(*includeInterfacesRegex)
+	if err != nil {
+		return fmt.Errorf("error compiling include.interfaces-regex: %v", err)
+	}
+	return nil
 }
 
 func startServer() {
@@ -101,7 +124,8 @@ func handleMetricsRequest(w http.ResponseWriter, request *http.Request) {
 			includedIfaceNames[index] = strings.Trim(includedIfaceName, " ")
 		}
 	}
-	transceiverCollector := transceivercollector.NewCollector(excludedIfaceNames, includedIfaceNames, *excludeInterfacesRegex, *includeInterfaceRegex, *excludeInterfacesDown, *collectInterfaceFeatures, *powerUnitdBm)
+
+	transceiverCollector := transceivercollector.NewCollector(excludedIfaceNames, includedIfaceNames, excludeInterfacesRegexCompiled, includeInterfacesRegexCompiled, *excludeInterfacesDown, *collectInterfaceFeatures, *powerUnitdBm)
 	wrapper := &transceiverCollectorWrapper{
 		collector: transceiverCollector,
 	}

--- a/transceiver-collector/collector.go
+++ b/transceiver-collector/collector.go
@@ -308,6 +308,11 @@ func (t *TransceiverCollector) getMonitoredInterfaces() ([]string, error) {
 		return []string{}, errors.New("Cannot include and exclude interfaces at the same time")
 	}
 
+	// check if the regex is a non empty string to prevent matching no interfaces
+	// when the default value of the cli flag is used
+	regexIncludeValid := t.includeInterfacesRegex.String() != ""
+	regexExcludeValid := t.excludeInterfacesRegex.String() != ""
+
 	ifaceNames := []string{}
 	for _, iface := range interfaces {
 		if iface.Flags&net.FlagLoopback > 0 {
@@ -322,10 +327,10 @@ func (t *TransceiverCollector) getMonitoredInterfaces() ([]string, error) {
 		if InterfacesIncluded && !contains(t.includeInterfaces, iface.Name) {
 			continue
 		}
-		if len(t.excludeInterfacesRegex.String()) > 0 && t.excludeInterfacesRegex.MatchString(iface.Name) {
+		if regexExcludeValid && t.excludeInterfacesRegex.MatchString(iface.Name) {
 			continue
 		}
-		if len(t.includeInterfacesRegex.String()) > 0 && !t.includeInterfacesRegex.MatchString(iface.Name) {
+		if regexIncludeValid && !t.includeInterfacesRegex.MatchString(iface.Name) {
 			continue
 		}
 


### PR DESCRIPTION
Hi there,

thanks for the exporter. We're currently using it in our Cumulus IP fabric and it's performing well. 

However, we've encountered speed issues and are looking to enhance functionality by allowing exclusion/inclusion of specific interfaces. Which also has the upside of having less metrics for not interesting interfaces.

I noticed a similar pull request (#4), but it appears the author hasn't addressed the requested changes.
The seperate cli feature switches and including of interfaces is included in this pull request.

In our case, we want to exclude interfaces like "vlan420" and "vni10187," and only include those matching the pattern "swp.*" using `'--include.interfaces-regex=swp.*'`

Additionally, I've tested `'--exclude.interfaces-regex=vni.*|vlan.*'`, and it behaves as expected. 

